### PR TITLE
Add option to allow zooming without pressing CTRL

### DIFF
--- a/app/disp_callbacks.c
+++ b/app/disp_callbacks.c
@@ -729,18 +729,18 @@ ddisplay_canvas_events (GtkWidget *canvas,
             case GDK_SCROLL_UP:
               if (sevent->state & GDK_SHIFT_MASK)
                   ddisplay_scroll_left(ddisp);
-              else if (sevent->state & GDK_CONTROL_MASK) {
+              else if (!(sevent->state & GDK_CONTROL_MASK) != (!prefs.wheel_zoom_without_modifier)) {
                   ddisplay_untransform_coords(ddisp, (int)sevent->x, (int)sevent->y, &middle.x, &middle.y);
 		  /* zooming with the wheel in small steps 1^(1/8) */
                   ddisplay_zoom_centered(ddisp, &middle, 1.090508);
               }
-              else 
+              else
                   ddisplay_scroll_up(ddisp);
               break;
             case GDK_SCROLL_DOWN:
               if (sevent->state & GDK_SHIFT_MASK)
                   ddisplay_scroll_right(ddisp);
-              else if (sevent->state & GDK_CONTROL_MASK) { 
+              else if (!(sevent->state & GDK_CONTROL_MASK) != (!prefs.wheel_zoom_without_modifier)) { 
                   ddisplay_untransform_coords(ddisp, (int)sevent->x, (int)sevent->y, &middle.x, &middle.y);
 		  /* zooming with the wheel in small steps 1/(1^(1/8)) */
                   ddisplay_zoom_centered(ddisp, &middle, 0.917004);

--- a/app/preferences.c
+++ b/app/preferences.c
@@ -169,6 +169,9 @@ DiaPrefData prefs_data[] =
   { "reverse_rubberbanding_intersects", PREF_BOOLEAN, PREF_OFFSET(reverse_rubberbanding_intersects), 
     &default_true, UI_TAB, N_("Reverse dragging selects\nintersecting objects") },
 
+  { "wheel_zoom_without_modifier", PREF_BOOLEAN, PREF_OFFSET(wheel_zoom_without_modifier), 
+    &default_false, UI_TAB, N_("Mouse wheel zoom without modifier") },
+
   { "recent_documents_list_size", PREF_UINT, PREF_OFFSET(recent_documents_list_size), 
     &default_recent_documents, 0, N_("Recent documents list size:") },
 

--- a/app/preferences.h
+++ b/app/preferences.h
@@ -54,6 +54,7 @@ struct DiaPreferences {
   int reset_tools_after_create;
   int undo_depth;
   int reverse_rubberbanding_intersects;
+  int wheel_zoom_without_modifier;
   guint recent_documents_list_size;
 
   gchar* length_unit;


### PR DESCRIPTION
Hi,

In many graphical tools / CAD programs it's common practice to navigate through the sheet just by zooming with the mouse wheel, without pressing any modifiers like CTRL. I really miss this feature in Dia, so I decided to implement it by myself.

This pull request adds a new checkbox to the preferences dialog:
![preferences_screenshot](https://cloud.githubusercontent.com/assets/5374821/16710594/3d01fce4-4634-11e6-94fe-fcfd552be379.png)

Per default the checkbox is not checked and the behaviour of Dia is not affected at all. If the checkbox is checked, the logic of the CTRL modifier while spinning the mouse wheel is inverted. This means that spinning the wheel without pressing CTRL will zoom, and spinning the wheel with pressing CTRL will scroll vertically.
