### PR TITLE
reproducible automated CI build with shippable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:latest
+
+RUN apt-get update
+RUN apt-get -y install libpango1.0-dev autotools-dev libfreetype6-dev\
+    automake autoconf libtool intltool libtool-bin\
+    libgtk2.0-dev libxml2-dev
+
+CMD /bin/bash
+
+
+

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,4 +1,4 @@
-build_image: magwas/diabuild:master
+build_image: magwas/diabuild
 #the next three lines are just to workaround a shippable bug
 language: python
 python:

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,11 @@
+build_image: magwas/diabuild:master
+#the next three lines are just to workaround a shippable bug
+language: python
+python:
+  - 2.7
+archive: true
+build:
+  ci:
+    - ./autogen.sh
+    - make
+    - make check


### PR DESCRIPTION
And also docker based, with the Dockerfile in this repository.
Currently shippable.yml uses image from my docker hub repo (magwas/diabuild), as there is no "official" build image.
