### PR TITLE
Bug 780316 - Set free attribute to g_free in element_change_new

### DIFF
--- a/lib/element.c
+++ b/lib/element.c
@@ -503,7 +503,7 @@ element_change_new (const Point *corner,
 
   ec->object_change.apply  = _element_change_swap;
   ec->object_change.revert = _element_change_swap;
-  ec->object_change.free = NULL;
+  ec->object_change.free = (ObjectChangeFreeFunc) g_free;
 
   ec->element = elem;
   ec->corner = elem->corner;


### PR DESCRIPTION
Hi,

Here is a solution for this bug:
https://bugzilla.gnome.org/show_bug.cgi?id=780316#c1

Thank you for taking it into account.