### PR TITLE
Support enumerative ext attributes

### DIFF
--- a/doc/custom-shapes
+++ b/doc/custom-shapes
@@ -272,6 +272,7 @@ To extend your custom shape with custom attributes you can put something like:
     <ext_attribute name="Integer" type="int" />
     <ext_attribute name="String" type="string" />
     <ext_attribute name="Float" type="real" />
+    <ext_attribute name="Enum" type="enum" values="lit1, lit2, lit3" />
   </ext_attributes>
 
 between the <shape></shape> tags. The effect will be some custom properties

--- a/doc/en/custom-shapes.xml
+++ b/doc/en/custom-shapes.xml
@@ -586,6 +586,7 @@
     <ext_attribute name="Integer" type="int" />
     <ext_attribute name="String" type="string" />
     <ext_attribute name="Float" type="real" />
+    <ext_attribute name="Enum" type="enum" values="lit1, lit2, lit3" />
   </ext_attributes>
 ]]>
       </literal>

--- a/doc/shape.dtd
+++ b/doc/shape.dtd
@@ -46,7 +46,8 @@
 <!ATTLIST ext_attribute
   name CDATA #REQUIRED
   type CDATA #REQUIRED
-  description CDATA #IMPLIED >
+  description CDATA #IMPLIED
+  values CDATA #IMPLIED>
 
 <!ELEMENT svg:svg (svg:g | svg:line | svg:polyline | svg:polygon | svg:rect |
                    svg:circle | svg:ellipse | svg:path | svg:image | svg:text)* >

--- a/lib/prop_inttypes.c
+++ b/lib/prop_inttypes.c
@@ -604,6 +604,13 @@ enumprop_set_from_offset(EnumProperty *prop,
   }
 }
 
+static int
+enumprop_get_data_size(EnumProperty *prop)
+{
+  return sizeof (prop->enum_data); /* only the field */
+}
+
+
 static const PropertyOps enumprop_ops = {
   (PropertyType_New) enumprop_new,
   (PropertyType_Free) noopprop_free,
@@ -616,7 +623,8 @@ static const PropertyOps enumprop_ops = {
 
   (PropertyType_CanMerge) noopprop_can_merge, 
   (PropertyType_GetFromOffset) enumprop_get_from_offset,
-  (PropertyType_SetFromOffset) enumprop_set_from_offset
+  (PropertyType_SetFromOffset) enumprop_set_from_offset,
+  (PropertyType_GetDataSize) enumprop_get_data_size
 };
 
 /********************************/

--- a/objects/custom/custom_object.c
+++ b/objects/custom/custom_object.c
@@ -338,6 +338,35 @@ custom_setup_properties (ShapeInfo *info, xmlNodePtr node)
 	ptype = g_strdup((gchar *) str);
 	xmlFree(str);
 
+        if (!g_strcmp0(ptype, "enum"))
+        {
+          str = xmlGetProp(node, (const xmlChar *)"values");
+          if (str) {
+            gchar **tokens;
+            gchar* values = g_strdup((gchar *) str);
+            gint count = 0;
+            gint j;
+            PropEnumData* data;
+
+            /* find and count enum literals (comma, colon, semi-colon or space separated)*/
+            tokens = g_strsplit(values, ",", -1);
+            for (count=0; tokens[count]; ++count);
+
+            /* last element (+1) is the terminator */
+            data = g_new0(PropEnumData, count + 1);
+            for (j=0; j < count; ++j) {
+              gchar* lit = g_strdup(tokens[j]);
+              data[j] = (PropEnumData) { g_strstrip(lit), j };
+            }
+            /* this will not be freed */
+            info->props[i].extra_data = data;
+
+            g_strfreev(tokens);
+            g_free(values);
+            xmlFree(str);
+          }
+        }
+
 	/* we got here, then fill an entry */
 	info->props[i].name = g_strdup_printf("custom:%s", pname);
 	info->props[i].type = ptype;
@@ -351,6 +380,7 @@ custom_setup_properties (ShapeInfo *info, xmlNodePtr node)
 	  xmlFree(str);
 	}
 	info->props[i++].description = pname;
+
       }
     }
   }


### PR DESCRIPTION
This patch add support to enumerative type `enum` for ext_attributes. 
For example:
```
 <ext_attributes>
   <ext_attribute name="MyEnum" type="enum" values="lit1, lit2, lit3"/>
 </ext_attributes>
```

literals for values are comma-separated. 
