### PR TITLE
Switch tab doesn't set active display correctly.

### DIFF
--- a/app/display.c
+++ b/app/display.c
@@ -1356,6 +1356,15 @@ ddisplay_update_statusbar(DDisplay *ddisp)
   update_mainpoint_status (ddisp);
 }
 
+// only set the active display
+void set_display(DDisplay *ddisp)
+{
+  if (ddisp != active_display)
+  {
+    active_display = ddisp;
+  }
+}
+
 void
 display_set_active(DDisplay *ddisp)
 {

--- a/app/display.h
+++ b/app/display.h
@@ -185,6 +185,7 @@ void display_update_menu_state(DDisplay *ddisp);
 void ddisplay_update_statusbar(DDisplay *ddisp);
 void ddisplay_do_update_menu_sensitivity (DDisplay *ddisp);
 
+void set_display(DDisplay *ddisp);
 void display_set_active(DDisplay *ddisp);
 
 void ddisplay_im_context_preedit_reset(DDisplay *ddisp, Focus *focus);

--- a/app/interface.c
+++ b/app/interface.c
@@ -332,6 +332,15 @@ close_notebook_page_callback (GtkButton *button,
   ddisplay_close (ddisp);
 }
 
+void switch_notebook_page_callback(GtkNotebook *notebook,
+                                   GtkWidget *page,
+                                   guint page_num,
+                                   gpointer user_data)
+{
+  DDisplay *ddisp = g_object_get_data (G_OBJECT (page), "DDisplay");
+  set_display(ddisp);
+}
+
 /*!
  * Called when the widget's window "size, position or stacking"
  * changes. Needs GDK_STRUCTURE_MASK set.
@@ -607,6 +616,8 @@ use_integrated_ui_for_display_shell(DDisplay *ddisp, char *title)
   notebook_page_index = gtk_notebook_append_page (GTK_NOTEBOOK(ui.diagram_notebook),
                                                   ddisp->container,
                                                   tab_label_container);
+  
+  g_signal_connect(G_OBJECT(ui.diagram_notebook), "switch-page", G_CALLBACK(switch_notebook_page_callback), NULL);
 
   g_object_set_data (G_OBJECT (ddisp->container), "DDisplay",  ddisp);
   g_object_set_data (G_OBJECT (ddisp->container), "tab-label", label);


### PR DESCRIPTION
This is fixing https://gitlab.gnome.org/GNOME/dia/issues/403

Switch tab doesn't set active display correctly. but cannot use `display_set_active` for it not only just set active display but also trigger some evetns.